### PR TITLE
Add label based on component

### DIFF
--- a/.github/workflows/label_from_issue_form.yml
+++ b/.github/workflows/label_from_issue_form.yml
@@ -1,0 +1,20 @@
+name: Create Label
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get issue type
+        run: echo "::set-output name=issue_type::${{ issue.body.match('(?<=More Information\.\n\n)[\w]+(?=\n\nESP-IDF version\.$)')[1] }}"
+        id: issue-type
+
+      - name: Create label
+        uses: peter-evans/create-or-update-label@v2
+        with:
+          name: ${{ steps.issue-type.outputs.issue_type }}
+          color: f29513
+          description: 'Component.'


### PR DESCRIPTION
Adds label to newly created issue based on what component was picked in issue form.

# Checklist

- [ ] Component contains License
- [ ] Component contains README.md
- [ ] Component contains idf_component.yml file with `url` field defined
- [ ] Component was added to [upload job](https://github.com/espressif/idf-extra-components/blob/master/.github/workflows/upload_component.yml#L18)
- [ ] Component was added to [build job](https://github.com/espressif/idf-extra-components/blob/master/test_app/CMakeLists.txt#L8)
- [ ] _Optional:_ Component contains unit tests
- [ ] CI passing

# Change description
_Please describe your change here_
